### PR TITLE
Set intent to avoid crash on Android v. 6.

### DIFF
--- a/app/src/main/java/io/gonative/android/OneSignalNotificationHandler.java
+++ b/app/src/main/java/io/gonative/android/OneSignalNotificationHandler.java
@@ -32,6 +32,7 @@ public class OneSignalNotificationHandler implements OneSignal.NotificationOpene
         String launchUrl = notification.payload.launchURL;
         if (launchUrl != null && !launchUrl.isEmpty()) {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(launchUrl));
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             context.startActivity(intent);
             return;
         }


### PR DESCRIPTION
See https://github.com/OneSignal/OneSignal-Android-SDK/issues/199
Push messages which contain a launch url crashes the app. Setting the intent flag fixes this.